### PR TITLE
refactor: remove repeated code for first/last find

### DIFF
--- a/src/find.ts
+++ b/src/find.ts
@@ -54,28 +54,17 @@ export async function findComment(
     issue_number: inputs.issueNumber
   }
 
-  if (inputs.direction == 'first') {
-    for await (const {data: comments} of octokit.paginate.iterator(
-      octokit.rest.issues.listComments,
-      parameters
-    )) {
-      // Search each page for the comment
-      const comment = comments.find(comment =>
-        findCommentPredicate(inputs, comment)
-      )
-      if (comment) return comment
-    }
-  } else {
-    // direction == 'last'
-    const comments = await octokit.paginate(
-      octokit.rest.issues.listComments,
-      parameters
-    )
+  const comments = await octokit.paginate(
+    octokit.rest.issues.listComments,
+    parameters
+  )
+  if (inputs.direction == 'last') {
     comments.reverse()
-    const comment = comments.find(comment =>
-      findCommentPredicate(inputs, comment)
-    )
-    if (comment) return comment
   }
+  const comment = comments.find(comment =>
+    findCommentPredicate(inputs, comment)
+  )
+  if (comment) return comment;
+  
   return undefined
 }

--- a/src/find.ts
+++ b/src/find.ts
@@ -64,7 +64,7 @@ export async function findComment(
   const comment = comments.find(comment =>
     findCommentPredicate(inputs, comment)
   )
-  if (comment) return comment;
-  
+  if (comment) return comment
+
   return undefined
 }


### PR DESCRIPTION
This PR removes a few lines of duplicated code, and enforces the first/last distinction 

PR probably *wants* for a test of first / last correctness, but as far as I can tell that involves  abstracting `findComment` so that mock Octokit results can be passed. (first/last configuration is not currently under test).