### PR TITLE
Add the node_id to the available output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           body-includes: search string 1
       - if: steps.fc1.outputs.comment-id != 620947762
         run: exit 1
+      - if: steps.fc1.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDYyMDk0Nzc2Mg=='
+        run: exit 1
       - if: steps.fc1.outputs.comment-body != 'search string 1'
         run: exit 1
       - if: steps.fc1.outputs.comment-author != 'retepsnave'
@@ -73,6 +75,8 @@ jobs:
           comment-author: retepsnave
       - if: steps.fc2.outputs.comment-id != 620947762
         run: exit 1
+      - if: steps.fc2.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDYyMDk0Nzc2Mg=='
+        run: exit 1
 
       - name: Find comment by body-includes and author
         uses: ./
@@ -82,6 +86,8 @@ jobs:
           comment-author: peter-evans
           body-includes: search string 1
       - if: steps.fc3.outputs.comment-id != 620947858
+        run: exit 1
+      - if: steps.fc3.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDYyMDk0Nzg1OA=='
         run: exit 1
 
       - name: No matching comment found
@@ -93,6 +99,8 @@ jobs:
           body-includes: this string will not be found
       - if: steps.fc4.outputs.comment-id != ''
         run: exit 1
+      - if: steps.fc4.outputs.comment-node-id != ''
+        run: exit 1
 
       - name: Find comment by body-includes (requiring pagination)
         uses: ./
@@ -102,6 +110,8 @@ jobs:
           body-includes: search string 2
       - if: steps.fc5.outputs.comment-id != 703343658
         run: exit 1
+      - if: steps.fc5.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDcwMzM0MzY1OA=='
+        run: exit 1
 
       - name: Find comment in merged PR
         uses: ./
@@ -110,6 +120,8 @@ jobs:
           issue-number: 4
           body-includes: search string 3
       - if: steps.fc6.outputs.comment-id != 703352283
+        run: exit 1
+      - if: steps.fc6.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDcwMzM1MjI4Mw=='
         run: exit 1
 
       - name: Find the last comment by body-includes and author
@@ -122,6 +134,8 @@ jobs:
           direction: last
       - if: steps.fc7.outputs.comment-id != 771260630
         run: exit 1
+      - if: steps.fc7.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDc3MTI2MDYzMA=='
+        run: exit 1
 
       - name: Find comment by body-regex
         uses: ./
@@ -130,6 +144,8 @@ jobs:
           issue-number: 1
           body-regex: '^.*search string 1.*$'
       - if: steps.fc8.outputs.comment-id != 620947762
+        run: exit 1
+      - if: steps.fc8.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDYyMDk0Nzc2Mg=='
         run: exit 1
 
       - name: Find nth comment by body-includes
@@ -140,6 +156,8 @@ jobs:
           body-includes: comment 1
           nth: 2
       - if: steps.fc9.outputs.comment-id != 703343294
+        run: exit 1
+      - if: steps.fc9.outputs.comment-node-id != 'MDEyOklzc3VlQ29tbWVudDcwMzM0MzI5NA=='
         run: exit 1
 
   package:

--- a/__test__/find.unit.test.ts
+++ b/__test__/find.unit.test.ts
@@ -16,6 +16,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -37,6 +38,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -60,6 +62,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -81,6 +84,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -104,6 +108,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -125,6 +130,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -148,6 +154,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -169,6 +176,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -190,6 +198,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -213,6 +222,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -234,6 +244,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -255,6 +266,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -276,6 +288,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -299,6 +312,7 @@ describe('findCommentPredicate tests', () => {
         },
         {
           id: 1,
+          node_id: 'tornado',
           body: `Toto, I've a feeling we're not in Kansas anymore.`,
           user: {login: 'dorothy'},
           created_at: '2020-01-01T00:00:00Z'
@@ -313,30 +327,35 @@ describe('findMatchingComment tests', () => {
   const testComments = [
     {
       id: 1,
+      node_id: 'tornado',
       body: `Toto, I've a feeling we're not in Kansas anymore.`,
       user: {login: 'dorothy'},
       created_at: '2020-01-01T00:00:00Z'
     },
     {
       id: 2,
+      node_id: 'poppies',
       body: `You've always had the power, my dear. You just had to learn it for yourself.`,
       user: {login: 'glinda'},
       created_at: '2020-01-01T00:00:00Z'
     },
     {
       id: 3,
+      node_id: 'rubyslippers',
       body: `I'll get you, my pretty, and your little dog too!`,
       user: {login: 'wicked-witch'},
       created_at: '2020-01-01T00:00:00Z'
     },
     {
       id: 4,
+      node_id: 'auntieem',
       body: `Toto, I've a feeling we're not in Kansas anymore.`,
       user: {login: 'dorothy'},
       created_at: '2020-01-01T00:00:00Z'
     },
     {
       id: 5,
+      node_id: 'verybadwizard',
       body: `I'll get you, my pretty, and your little dog too!`,
       user: {login: 'wicked-witch'},
       created_at: '2020-01-01T00:00:00Z'

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,8 @@ inputs:
 outputs:
   comment-id:
     description: 'The id of the matching comment found.'
+  comment-node-id:
+    description: 'The GraphQL node id of the matching comment found.'
   comment-body:
     description: 'The body of the matching comment found.'
   comment-author:

--- a/dist/index.js
+++ b/dist/index.js
@@ -157,12 +157,14 @@ function run() {
             const comment = yield (0, find_1.findComment)(inputs);
             if (comment) {
                 core.setOutput('comment-id', comment.id.toString());
+                core.setOutput('comment-node-id', comment.node_id);
                 core.setOutput('comment-body', comment.body);
                 core.setOutput('comment-author', comment.user ? comment.user.login : '');
                 core.setOutput('comment-created-at', comment.created_at);
             }
             else {
                 core.setOutput('comment-id', '');
+                core.setOutput('comment-node-id', '');
                 core.setOutput('comment-body', '');
                 core.setOutput('comment-author', '');
                 core.setOutput('comment-created-at', '');

--- a/src/find.ts
+++ b/src/find.ts
@@ -13,6 +13,7 @@ export interface Inputs {
 
 export interface Comment {
   id: number
+  node_id: string
   body?: string
   user: {
     login: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,11 +25,13 @@ async function run(): Promise<void> {
 
     if (comment) {
       core.setOutput('comment-id', comment.id.toString())
+      core.setOutput('comment-node-id', comment.node_id)
       core.setOutput('comment-body', comment.body)
       core.setOutput('comment-author', comment.user ? comment.user.login : '')
       core.setOutput('comment-created-at', comment.created_at)
     } else {
       core.setOutput('comment-id', '')
+      core.setOutput('comment-node-id', '')
       core.setOutput('comment-body', '')
       core.setOutput('comment-author', '')
       core.setOutput('comment-created-at', '')


### PR DESCRIPTION
I would like to use this action to find comments for minimization but that seems to require using the GraphQL API. The GraphQL API requires the `node_id` for the [`minimizeComment`](https://docs.github.com/en/graphql/reference/mutations#minimizecomment) and [`unminimizeComment`](https://docs.github.com/en/graphql/reference/mutations#unminimizecomment) mutations. Thankfully the REST API returns the GraphQL `node_id` property and as long as this passes it back we can then use it in GraphQL mutations!

I updated the action defintion, the declared shape of a `Comment`, and all the tests (both in `ts` and in the workflow).
